### PR TITLE
Fix membership registration 409 when logged in.

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -29,12 +29,13 @@ Spring Cloud Gateway serving as the single entry point for the UBC MMHC backend.
 | `JWT_COOKIE_NAME` | Cookie name for JWT | `JWT` |
 | `REDIS_HOST` | Redis host for rate limiting | `localhost` |
 | `REDIS_PORT` | Redis port | `6379` |
+| `REDIS_USER` / `REDISUSER` | Redis username (required for ACL-enabled Redis, e.g. Railway) | (empty) |
 | `REDIS_PASSWORD` | Redis password | (empty) |
 | `APPLICATION_PROFILE` | Active profile (`dev` omits rate limiting; `prod` omits rate limiting until Redis auth is configured) | `dev` |
 
 ### Railway Redis
 
-If the gateway uses the default profile with rate limiting (not `dev`/`prod`), set Redis credentials on the **gateway** service from your Railway Redis plugin, for example `REDISPASSWORD` or `REDIS_PASSWORD`. Without them you will see `NOAUTH` errors and `/api/membership/**` requests can fail when logged in.
+If the gateway uses the default profile with rate limiting (not `dev`/`prod`), set Redis credentials on the **gateway** service from your Railway Redis plugin, for example `REDISUSER`/`REDIS_USER` and `REDISPASSWORD`/`REDIS_PASSWORD`. Without them you will see `NOAUTH` errors and `/api/membership/**` requests can fail when logged in.
 
 The `prod` profile disables rate limiting so membership works without Redis; re-enable limiting after Redis env vars are set.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -30,6 +30,13 @@ Spring Cloud Gateway serving as the single entry point for the UBC MMHC backend.
 | `REDIS_HOST` | Redis host for rate limiting | `localhost` |
 | `REDIS_PORT` | Redis port | `6379` |
 | `REDIS_PASSWORD` | Redis password | (empty) |
+| `APPLICATION_PROFILE` | Active profile (`dev` omits rate limiting; `prod` omits rate limiting until Redis auth is configured) | `dev` |
+
+### Railway Redis
+
+If the gateway uses the default profile with rate limiting (not `dev`/`prod`), set Redis credentials on the **gateway** service from your Railway Redis plugin, for example `REDISPASSWORD` or `REDIS_PASSWORD`. Without them you will see `NOAUTH` errors and `/api/membership/**` requests can fail when logged in.
+
+The `prod` profile disables rate limiting so membership works without Redis; re-enable limiting after Redis env vars are set.
 
 ## Running Locally
 

--- a/gateway/src/main/resources/application-prod.yml
+++ b/gateway/src/main/resources/application-prod.yml
@@ -1,0 +1,38 @@
+# Production: omit Redis rate limiting unless REDIS_URL / REDISPASSWORD are configured.
+# Railway Redis requires authentication; missing password causes NOAUTH and breaks /api/membership/**.
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: stripe-webhook
+          uri: ${MEMBERSHIP_SERVICE_URI:http://localhost:8084}
+          predicates:
+            - Path=/api/stripe/webhook
+        - id: auth
+          uri: ${AUTH_SERVICE_URI:http://localhost:8082}
+          predicates:
+            - Path=/api/auth/**,/login/**,/oauth2/**
+        - id: user
+          uri: ${USER_SERVICE_URI:http://localhost:8083}
+          predicates:
+            - Path=/api/user/**
+        - id: blog
+          uri: ${USER_SERVICE_URI:http://localhost:8083}
+          predicates:
+            - Path=/api/blog/**
+        - id: membership
+          uri: ${MEMBERSHIP_SERVICE_URI:http://localhost:8084}
+          predicates:
+            - Path=/api/membership/**
+        - id: newsletter
+          uri: ${NEWSLETTER_SERVICE_URI:http://localhost:8085}
+          predicates:
+            - Path=/api/newsletter/**
+        - id: admin-memberships
+          uri: ${MEMBERSHIP_SERVICE_URI:http://localhost:8084}
+          predicates:
+            - Path=/api/admin/memberships/**
+        - id: admin-users
+          uri: ${USER_SERVICE_URI:http://localhost:8083}
+          predicates:
+            - Path=/api/admin/users/**

--- a/gateway/src/main/resources/application-prod.yml
+++ b/gateway/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
-# Production: omit Redis rate limiting unless REDIS_URL / REDISPASSWORD are configured.
-# Railway Redis requires authentication; missing password causes NOAUTH and breaks /api/membership/**.
+# Production gateway route configuration.
+# Redis-backed rate limiting is not configured in this profile.
 spring:
   cloud:
     gateway:

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -69,6 +69,7 @@ spring:
       host: ${REDISHOST:${REDIS_HOST:localhost}}
       port: ${REDISPORT:${REDIS_PORT:6379}}
       password: ${REDISPASSWORD:${REDIS_PASSWORD:}}
+      username: ${REDISUSER:${REDIS_USER:}}
 
 app:
   frontend-url: ${FRONTEND_URL:http://localhost:3000}

--- a/services/auth-service/src/main/java/com/ubcmmhcsoftware/auth/service/JWTService.java
+++ b/services/auth-service/src/main/java/com/ubcmmhcsoftware/auth/service/JWTService.java
@@ -45,7 +45,9 @@ public class JWTService {
                 .type("JWT")
                 .and()
                 .subject(userDetails.getId().toString())
-                .claim("email", userDetails.getUsername())
+                .claim("email", userDetails.getUsername() != null
+                        ? userDetails.getUsername().trim().toLowerCase()
+                        : null)
                 .claim("roles", userDetails.getAuthorities()
                         .stream()
                         .map(GrantedAuthority::getAuthority)

--- a/services/auth-service/src/main/java/com/ubcmmhcsoftware/auth/service/JWTService.java
+++ b/services/auth-service/src/main/java/com/ubcmmhcsoftware/auth/service/JWTService.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 
 @Service
@@ -46,7 +47,7 @@ public class JWTService {
                 .and()
                 .subject(userDetails.getId().toString())
                 .claim("email", userDetails.getUsername() != null
-                        ? userDetails.getUsername().trim().toLowerCase()
+                        ? userDetails.getUsername().trim().toLowerCase(Locale.ROOT)
                         : null)
                 .claim("roles", userDetails.getAuthorities()
                         .stream()

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/repository/MembershipRepository.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/repository/MembershipRepository.java
@@ -11,15 +11,15 @@ import java.util.UUID;
 @Repository
 public interface MembershipRepository extends JpaRepository<Membership, UUID> {
 
-    Optional<Membership> findByEmail(String email);
+    Optional<Membership> findByEmailIgnoreCase(String email);
+
+    boolean existsByEmailIgnoreCase(String email);
 
     Optional<Membership> findByStripeCustomerId(String stripeCustomerId);
 
     Optional<Membership> findByStripeSubscriptionId(String subscriptionId);
 
     Optional<Membership> findByStripeSessionId(String sessionId);
-
-    boolean existsByEmail(String email);
 
     List<Membership> findByActiveAndPaymentStatus(boolean active, String paymentStatus);
 }

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/repository/MembershipRepository.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/repository/MembershipRepository.java
@@ -13,6 +13,8 @@ public interface MembershipRepository extends JpaRepository<Membership, UUID> {
 
     Optional<Membership> findByEmailIgnoreCase(String email);
 
+    List<Membership> findAllByEmailIgnoreCase(String email);
+
     boolean existsByEmailIgnoreCase(String email);
 
     Optional<Membership> findByStripeCustomerId(String stripeCustomerId);

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Locale;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -89,6 +90,8 @@ public class MembershipService {
                                                       MembershipRegistrationDTO dto,
                                                       UUID userId,
                                                       String email) throws StripeException {
+        boolean previouslyNewsletterOptedIn = membership.isNewsletterOptIn();
+
         if (membership.isActive()) {
             throw new IllegalStateException("A membership already exists for this email");
         }
@@ -111,6 +114,14 @@ public class MembershipService {
         PaymentMethod paymentMethod = dto.getPaymentMethod() != null ? dto.getPaymentMethod() : PaymentMethod.STRIPE;
         membership.setPaymentMethod(paymentMethod);
         membership = membershipRepository.save(membership);
+
+        if (!previouslyNewsletterOptedIn && dto.isNewsletterOptIn()) {
+            eventPublisher.publishMembershipCreated(MembershipCreatedEvent.builder()
+                    .membershipId(membership.getId())
+                    .email(email)
+                    .newsletterOptIn(true)
+                    .build());
+        }
 
         log.info("Resuming unpaid membership {} for {}", membership.getId(), email);
         return completeRegistration(membership, paymentMethod);
@@ -139,7 +150,7 @@ public class MembershipService {
     }
 
     private static String normalizeEmail(String email) {
-        return email == null ? "" : email.trim().toLowerCase();
+        return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
     }
 
     @Transactional

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
@@ -45,11 +45,11 @@ public class MembershipService {
             if (matches.size() == 1) {
                 toResume = matches.get(0);
             } else {
-                List<Membership> active = matches.stream().filter(Membership::isActive).toList();
-                if (active.size() == 1) {
-                    toResume = active.get(0);
+                List<Membership> activeMemberships = matches.stream().filter(Membership::isActive).toList();
+                if (activeMemberships.size() == 1) {
+                    toResume = activeMemberships.get(0);
                 } else {
-                    throw new IllegalStateException("A membership already exists for this email");
+                    throw new IllegalStateException("Multiple memberships found for this email; please contact support");
                 }
             }
             return resumeUnpaidMembership(toResume, dto, userId, email);

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
@@ -38,9 +38,20 @@ public class MembershipService {
         }
 
         String email = normalizeEmail(dto.getEmail());
-        Optional<Membership> existing = membershipRepository.findByEmailIgnoreCase(email);
-        if (existing.isPresent()) {
-            return resumeUnpaidMembership(existing.get(), dto, userId, email);
+        List<Membership> matches = membershipRepository.findAllByEmailIgnoreCase(email);
+        if (!matches.isEmpty()) {
+            Membership toResume;
+            if (matches.size() == 1) {
+                toResume = matches.get(0);
+            } else {
+                List<Membership> active = matches.stream().filter(Membership::isActive).toList();
+                if (active.size() == 1) {
+                    toResume = active.get(0);
+                } else {
+                    throw new IllegalStateException("A membership already exists for this email");
+                }
+            }
+            return resumeUnpaidMembership(toResume, dto, userId, email);
         }
 
         PaymentMethod paymentMethod = dto.getPaymentMethod() != null ? dto.getPaymentMethod() : PaymentMethod.STRIPE;

--- a/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
+++ b/services/membership-service/src/main/java/com/ubcmmhcsoftware/membership/service/MembershipService.java
@@ -36,8 +36,11 @@ public class MembershipService {
         if (userId != null && !userServiceClient.userExists(userId)) {
             throw new IllegalStateException("User not found. Please log in again.");
         }
-        if (membershipRepository.existsByEmail(dto.getEmail())) {
-            throw new IllegalStateException("A membership already exists for this email");
+
+        String email = normalizeEmail(dto.getEmail());
+        Optional<Membership> existing = membershipRepository.findByEmailIgnoreCase(email);
+        if (existing.isPresent()) {
+            return resumeUnpaidMembership(existing.get(), dto, userId, email);
         }
 
         PaymentMethod paymentMethod = dto.getPaymentMethod() != null ? dto.getPaymentMethod() : PaymentMethod.STRIPE;
@@ -45,7 +48,7 @@ public class MembershipService {
         Membership membership = Membership.builder()
                 .userId(userId)
                 .fullName(dto.getFullName())
-                .email(dto.getEmail())
+                .email(email)
                 .membershipType(dto.getMembershipType())
                 .studentId(dto.getStudentId())
                 .instagram(dto.getInstagram())
@@ -58,16 +61,52 @@ public class MembershipService {
 
         membership = membershipRepository.save(membership);
         log.info("Created pending membership {} for {} with payment method {}",
-                membership.getId(), dto.getEmail(), paymentMethod);
+                membership.getId(), email, paymentMethod);
 
         if (dto.isNewsletterOptIn()) {
             eventPublisher.publishMembershipCreated(MembershipCreatedEvent.builder()
                     .membershipId(membership.getId())
-                    .email(dto.getEmail())
+                    .email(email)
                     .newsletterOptIn(true)
                     .build());
         }
 
+        return completeRegistration(membership, paymentMethod);
+    }
+
+    private CheckoutSessionDTO resumeUnpaidMembership(Membership membership,
+                                                      MembershipRegistrationDTO dto,
+                                                      UUID userId,
+                                                      String email) throws StripeException {
+        if (membership.isActive()) {
+            throw new IllegalStateException("A membership already exists for this email");
+        }
+        if (userId != null && membership.getUserId() != null && !membership.getUserId().equals(userId)) {
+            throw new IllegalStateException("A membership already exists for this email");
+        }
+
+        if (userId != null && membership.getUserId() == null) {
+            membership.setUserId(userId);
+        }
+
+        membership.setFullName(dto.getFullName());
+        membership.setEmail(email);
+        membership.setMembershipType(dto.getMembershipType());
+        membership.setStudentId(dto.getStudentId());
+        membership.setInstagram(dto.getInstagram());
+        membership.setInstagramGroupchat(dto.isInstagramGroupchat());
+        membership.setNewsletterOptIn(dto.isNewsletterOptIn());
+
+        PaymentMethod paymentMethod = dto.getPaymentMethod() != null ? dto.getPaymentMethod() : PaymentMethod.STRIPE;
+        membership.setPaymentMethod(paymentMethod);
+        membership = membershipRepository.save(membership);
+
+        log.info("Resuming unpaid membership {} for {}", membership.getId(), email);
+        return completeRegistration(membership, paymentMethod);
+    }
+
+    private CheckoutSessionDTO completeRegistration(Membership membership,
+                                                    PaymentMethod paymentMethod) throws StripeException {
         if (paymentMethod == PaymentMethod.STRIPE) {
             Session session = stripeService.createCheckoutSession(membership);
 
@@ -86,6 +125,10 @@ public class MembershipService {
                 .sessionId(null)
                 .sessionUrl(null)
                 .build();
+    }
+
+    private static String normalizeEmail(String email) {
+        return email == null ? "" : email.trim().toLowerCase();
     }
 
     @Transactional
@@ -128,18 +171,18 @@ public class MembershipService {
     }
 
     public Optional<Membership> getMembershipByEmail(String email) {
-        return membershipRepository.findByEmail(email);
+        return membershipRepository.findByEmailIgnoreCase(normalizeEmail(email));
     }
 
     public boolean hasActiveMembership(String email) {
-        return membershipRepository.findByEmail(email)
+        return membershipRepository.findByEmailIgnoreCase(normalizeEmail(email))
                 .map(Membership::isActive)
                 .orElse(false);
     }
 
     @Transactional
     public CheckoutSessionDTO createRetryPaymentSession(String email) throws StripeException {
-        Membership membership = membershipRepository.findByEmail(email)
+        Membership membership = membershipRepository.findByEmailIgnoreCase(normalizeEmail(email))
                 .orElseThrow(() -> new IllegalStateException("No membership found for this email"));
 
         if (membership.isActive()) {
@@ -161,7 +204,7 @@ public class MembershipService {
 
     @Transactional
     public void manuallyApproveMembership(String memberEmail, PaymentMethod paymentMethod, String adminEmail) {
-        Membership membership = membershipRepository.findByEmail(memberEmail)
+        Membership membership = membershipRepository.findByEmailIgnoreCase(normalizeEmail(memberEmail))
                 .orElseThrow(() -> new IllegalStateException("No membership found for email: " + memberEmail));
 
         if (membership.isActive()) {


### PR DESCRIPTION
Resume unpaid memberships instead of rejecting duplicate emails, normalize email matching, disable gateway Redis rate limiting in prod until auth is set, and document Railway Redis configuration.